### PR TITLE
Extend test to prove failure on Perl-5.10-32bit

### DIFF
--- a/t/050-date.t
+++ b/t/050-date.t
@@ -16,24 +16,42 @@ sub test_date {
 
     isa_ok($h, 'HTTP::Headers::ActionPack::DateHeader');
 
-    is( $h->day, 'Mon', '... got the day');
-    is( $h->month, 'Apr', '... got the month');
-    is( $h->year, 2012, '... got the year');
-    is( $h->hour, 14, '... got the hour');
-    is( $h->minute, 14, '... got the minute');
-    is( $h->second, 19, '... got the second');
-
-    is( $h->as_string, 'Mon, 23 Apr 2012 14:14:19 GMT', '... got the expected string');
+    while (my ($k, $v) = splice @_, 0, 2) {
+        is $h->$k, $v, "... got the $k";
+    }
 }
 
 test_date(
-    HTTP::Headers::ActionPack::DateHeader->new_from_string('Mon, 23 Apr 2012 14:14:19 GMT')
+    HTTP::Headers::ActionPack::DateHeader->new_from_string('Mon, 23 Apr 2012 14:14:19 GMT'),
+    day => 'Mon', day_of_month => 23, month => 'Apr', year => 2012,
+    hour => 14, minute => 14, second => 19,
+    as_string => 'Mon, 23 Apr 2012 14:14:19 GMT',
+);
+
+test_date(
+    HTTP::Headers::ActionPack::DateHeader->new_from_string('Sat, 23 Apr 2112 14:14:19 GMT'),
+    day => 'Sat', day_of_month => 23, month => 'Apr', year => 2112,
+    hour => 14, minute => 14, second => 19,
+    as_string => 'Sat, 23 Apr 2112 14:14:19 GMT',
 );
 
 test_date(
     HTTP::Headers::ActionPack::DateHeader->new(
         scalar Time::Piece->gmtime( HTTP::Date::str2time( 'Mon, 23 Apr 2012 14:14:19 GMT' ) )
-    )
+    ),
+    day => 'Mon', day_of_month => 23, month => 'Apr', year => 2012,
+    hour => 14, minute => 14, second => 19,
+    as_string => 'Mon, 23 Apr 2012 14:14:19 GMT',
+);
+
+test_date(
+    HTTP::Headers::ActionPack::DateHeader->new(
+        scalar Time::Piece->gmtime( HTTP::Date::str2time( 'Sat, 23 Apr 2112 14:14:19 GMT' ) )
+    ),
+    day => 'Sat', day_of_month => 23, month => 'Apr', year => 2112,
+    hour => 14, minute => 14, second => 19,
+    as_string => 'Sat, 23 Apr 2112 14:14:19 GMT',
 );
 
 done_testing;
+


### PR DESCRIPTION
This package is not y2038-proof on (at least) 32bit Perl5.10.1 and below, due to (documented) caveats in Time::Piece. While H:H:ActionPack installs cleanly on those systems, the depending Web::Machine fails tests, where playing with year 2112.

I extended t/050-date.t in the 32bit-date branch to demonstrate the problem. This test (probably) still passes on all Perls 5.12 and above, but now fails on 5.10-32bit (and probably below).

I'm not sure, how to fix the problem appropriatly. The Time::Piece docu suggests DateTime in such cases.
